### PR TITLE
Added two style options for tooltip offset

### DIFF
--- a/viz/treemap/src/index.js
+++ b/viz/treemap/src/index.js
@@ -68,7 +68,7 @@ function createRoot() {
 }
 
 
-function mouseOver(elem, d, tooltip) {
+function mouseOver(elem, d, tooltip, tooltipXOffset, tooltipYOffset) {
   d3.select(elem).attr('opacity', 1);
   var dataKey = d.data.key ? d.data.key : 'total';
   var tooltipText = dataKey + ': ' + d.value;
@@ -79,8 +79,8 @@ function mouseOver(elem, d, tooltip) {
     .delay(100)
     .duration(600)
     .style('visibility', 'visible')
-    .style('top', boundingBox.top + 5 + 'px')
-    .style('left', boundingBox.left + 5 + 'px');
+    .style('top', (boundingBox.top + tooltipYOffset) + 'px')
+    .style('left', (boundingBox.left + tooltipXOffset) + 'px');
 }
 
 function mouseOut(elem, d, tooltip) {
@@ -167,7 +167,7 @@ function render(root, style, colorScale) {
     .attr('stroke', 'black')
     .attr('opacity', 0.2)
     .on('mouseover', function(d) {
-      mouseOver(this, d, tooltip);
+      mouseOver(this, d, tooltip, style.tooltipXOffset, style.tooltipYOffset);
     })
     .on('mouseout', function(d) {
       mouseOut(this, d, tooltip);

--- a/viz/treemap/src/index.json
+++ b/viz/treemap/src/index.json
@@ -55,6 +55,18 @@
           "defaultValue": "0"
         },
         {
+          "type": "INTERVAL",
+          "id": "tooltipXOffset",
+          "label": "Horizontal tooltip offset",
+          "defaultValue": "5"
+        },
+        {
+          "type": "INTERVAL",
+          "id": "tooltipYOffset",
+          "label": "Vertical tooltip offset",
+          "defaultValue": "5"
+        },
+        {
           "type": "FONT_SIZE",
           "id": "fontSize",
           "label": "Font Size",


### PR DESCRIPTION
Added two style options to set horizontal and vertical offset for tooltip. This, apart from aesthetic motivation, can help in cases for small nodes. Once you hovered over the element the onMouseOver event was triggered and the tooltip appeared on top of it, where your mouse is, forcing now onMouseOut event. This could result in a constant transition loop.